### PR TITLE
Small Gene Expression Fixes

### DIFF
--- a/screen2.0/src/app/applets/gene-expression/MultiSelect.tsx
+++ b/screen2.0/src/app/applets/gene-expression/MultiSelect.tsx
@@ -4,7 +4,7 @@ import TextField from '@mui/material/TextField';
 import Autocomplete, { AutocompleteChangeDetails, AutocompleteChangeReason } from '@mui/material/Autocomplete';
 import CheckBoxOutlineBlankIcon from '@mui/icons-material/CheckBoxOutlineBlank';
 import CheckBoxIcon from '@mui/icons-material/CheckBox';
-import { Box, Divider, FormControlLabel, Paper } from '@mui/material';
+import { Box, Chip, Divider, FormControlLabel, Paper } from '@mui/material';
 import { capitalizeWords } from '../../search/_ccredetails/utils';
 
 const icon = <CheckBoxOutlineBlankIcon fontSize="small" />;
@@ -116,7 +116,7 @@ const MultiSelect = <T extends (string | {label: string; [key:string]: unknown})
     )
   })
 
-  //type guard to en
+  //type guard
   function isLabeledObject(value: unknown): value is { label: string; [key: string]: unknown } {
     return (
       value !== null &&
@@ -127,10 +127,11 @@ const MultiSelect = <T extends (string | {label: string; [key:string]: unknown})
   }
 
   return (
-    <Autocomplete
+    <Autocomplete<T, true> //Type of option was being incorrectly inferred to be T | T[] (maybe due to overriding MultiSelectOnChange? idk)
       multiple
       limitTags={limitTags}
       size={size}
+      open
       value={internalValue}
       onChange={handleChange}
       id="checkboxes-tags-demo"
@@ -170,22 +171,39 @@ const MultiSelect = <T extends (string | {label: string; [key:string]: unknown})
       )}
       //Parent element of options contained within above {paperProps.children}
       ListboxComponent={ListboxComponent}
-      //Each option. Type of option was incorrectly inferred to be T | T[] (maybe due to overriding MultiSelectOnChange? idk)
-      renderOption={(props, option: T, { selected }) => {
+      //Each option
+      renderOption={(props, option, { selected }) => {
         const { key, ...optionProps } = props;
         return (
           <li key={key} {...optionProps}>
             <Checkbox
-              id={'checkbox-' + option}
+              id={'checkbox-' + (isLabeledObject(option) ? option.label : option)}
               icon={icon}
+              size='small'
               checkedIcon={checkedIcon}
               style={{ marginRight: 8 }}
               checked={selected}
+              indeterminate={selected && (getOptionDisabled && getOptionDisabled(option))}
             />
             {capitalizeWords(isLabeledObject(option) ? option.label : option)}
           </li>
         );
       }}
+      //each tag
+      renderTags={(tagValue, getTagProps) =>
+        tagValue
+        .filter(option => !getOptionDisabled || !getOptionDisabled(option))
+        .map((option, index) => {
+          const { key, ...tagProps } = getTagProps({ index });
+          return (
+            <Chip
+              key={key}
+              label={isLabeledObject(option) ? option.label : option}
+              {...tagProps}
+            />
+          );
+        })
+      }
     />
   );
 }

--- a/screen2.0/src/app/applets/gene-expression/MultiSelect.tsx
+++ b/screen2.0/src/app/applets/gene-expression/MultiSelect.tsx
@@ -131,7 +131,6 @@ const MultiSelect = <T extends (string | {label: string; [key:string]: unknown})
       multiple
       limitTags={limitTags}
       size={size}
-      open
       value={internalValue}
       onChange={handleChange}
       id="checkboxes-tags-demo"

--- a/screen2.0/src/app/applets/gene-expression/geneexpression.tsx
+++ b/screen2.0/src/app/applets/gene-expression/geneexpression.tsx
@@ -300,6 +300,10 @@ export function GeneExpression(props: {
 
   const handleSetBiosamples: MultiSelectOnChange<BiosampleType> = (_, value) => {
     setBiosamples(value)
+    //when changing biosample types, need to manually modify the selected tissues to uncheck those which no longer
+    setSelectedTissues(
+      availableTissues.filter(x => x.types.some(y => value.includes(y)))
+    )
   }
 
   const handleSetGene = (newGene: string) => {
@@ -498,6 +502,7 @@ export function GeneExpression(props: {
           <FormLabel>{biosamples.length === allBiosampleTypes.length ? "Biosample Types" : <i>Biosample Types*</i>}</FormLabel>
           <MultiSelect
             options={allBiosampleTypes}
+            value={biosamples}
             onChange={handleSetBiosamples}
             placeholder="Filter Biosamples"
             limitTags={2}
@@ -505,9 +510,9 @@ export function GeneExpression(props: {
         </FormControl>
         <FormControl>
           <FormLabel>{selectedTissues.length === availableTissues.length ? "Tissues" : <i>Tissues*</i>}</FormLabel>
-          {/* disabling options works, but they're still checked... need to at least show them as unchecked. */}
           <MultiSelect
             options={availableTissues}
+            value={selectedTissues}
             getOptionDisabled={option => !option.types.some(x => biosamples.includes(x))}
             onChange={handleSetTissues}
             placeholder="Filter Tissues"

--- a/screen2.0/src/app/applets/gene-expression/geneexpression.tsx
+++ b/screen2.0/src/app/applets/gene-expression/geneexpression.tsx
@@ -19,9 +19,12 @@ import { tissueColors } from "../../../common/lib/colors"
 import MultiSelect, { MultiSelectOnChange } from "./MultiSelect"
 import { capitalizeWords } from "../../search/_ccredetails/utils"
 
-const biosampleTypes = ["cell line", "primary cell", "tissue", "in vitro differentiated cells" ];
+type BiosampleType = "cell line" | "primary cell" | "tissue" | "in vitro differentiated cells"
+const allBiosampleTypes: BiosampleType[] = ["cell line", "primary cell", "tissue", "in vitro differentiated cells"]
 
 type Assembly = "GRCh38" | "mm10"
+
+type MultiSelectTissue = {label: string, types: BiosampleType[]}
 
 //extracted from generated types, needed the nested type to pass as type argument to BarData<T>
 type GeneDataset = { __typename?: 'GeneDataset', biosample: string, tissue?: string | null, cell_compartment?: string | null, biosample_type?: string | null, assay_term_name?: string | null, accession: string, gene_quantification_files?: Array<{ __typename?: 'GeneQuantificationFile', accession: string, biorep?: number | null, quantifications?: Array<{ __typename?: 'GeneQuantification', tpm: number, file_accession: string } | null> | null } | null> | null }
@@ -37,13 +40,12 @@ export function GeneExpression(props: {
   const urlGene = searchParams.get("gene")
   const router = useRouter()
   const pathname = usePathname()
-
   //If genes passed as prop, use those. This is case in cCRE Details. Else use url gene if passed, default to APOE
   const [gene, setGene] = useState<string>(props.genes ? props?.genes[0]?.name : (urlGene ?? "APOE"))
   const [assembly, setAssembly] = useState<Assembly>(initialAssembly)
-  const [biosamples, setBiosamples] = useState<string[]>(biosampleTypes)
-  const [availableTissues, setAvailableTissues] = useState<string[]>([])
-  const [selectedTissues, setSelectedTissues] = useState<string[]>([])
+  const [biosamples, setBiosamples] = useState<BiosampleType[]>(allBiosampleTypes)
+  const [availableTissues, setAvailableTissues] = useState<MultiSelectTissue[]>([])
+  const [selectedTissues, setSelectedTissues] = useState<MultiSelectTissue[]>([])
   const [viewBy, setViewBy] = useState<"byTissueMaxTPM" | "byExperimentTPM" | "byTissueTPM">("byExperimentTPM")
   const [RNAtype, setRNAType] = useState<"all" | "polyA plus RNA-seq" | "total RNA-seq">("total RNA-seq")
   const [scale, setScale] = useState<"linearTPM" | "logTPM">("linearTPM")
@@ -102,10 +104,19 @@ export function GeneExpression(props: {
     fetchPolicy: "cache-and-network",
     nextFetchPolicy: "cache-first",
     onCompleted(data) {
-      const uniqueTissues = []
-      data.gene_dataset.forEach(x => {if (!uniqueTissues.includes(x.tissue)) uniqueTissues.push(x.tissue)})
-      setAvailableTissues(uniqueTissues.sort())
-      setSelectedTissues(uniqueTissues.sort())
+      const tissues: MultiSelectTissue[] = []
+      data.gene_dataset.forEach(x => {
+        const existingEntry = tissues.find(y => y.label === x.tissue)
+        if (!existingEntry) { // if tissue not cataloged, add to set
+          tissues.push({label: x.tissue, types: [x.biosample_type as BiosampleType]})
+        } else if (!existingEntry.types.includes(x.biosample_type as BiosampleType)){ //if tissue cataloged, but an exisitng biosample type doesn't, add biosample type
+          existingEntry.types.push(x.biosample_type as BiosampleType)
+        }
+      })
+      
+      const sortedTissues = tissues.sort((a, b) => a.label.localeCompare(b.label))
+      setAvailableTissues(sortedTissues)
+      setSelectedTissues(sortedTissues)
     },
   })
 
@@ -134,8 +145,8 @@ export function GeneExpression(props: {
     if (dataExperiments && dataExperiments.gene_dataset.length > 0) {
       //Filter data points
       const filteredData = dataExperiments.gene_dataset
-        .filter(d => biosamples.includes(d.biosample_type)) //biosample type
-        .filter(d => selectedTissues.includes(d.tissue)) //tissue
+        .filter(d => biosamples.includes(d.biosample_type as BiosampleType)) //biosample type
+        .filter(d => selectedTissues.some(x => x.label === d.tissue)) //tissue
         .filter(d => RNAtype === "all" || d.assay_term_name === RNAtype) //RNA type
         .filter(d => sampleMatchesSearch(d)) //search
       //holder for plot data as replicates are parsed for each experiment
@@ -283,11 +294,11 @@ export function GeneExpression(props: {
     )
   }, [scale])
 
-  const handleSetTissues: MultiSelectOnChange = (_, value) => {
+  const handleSetTissues: MultiSelectOnChange<MultiSelectTissue> = (_, value) => {
     setSelectedTissues(value)
   }
 
-  const handleSetBiosamples: MultiSelectOnChange = (_, value) => {
+  const handleSetBiosamples: MultiSelectOnChange<BiosampleType> = (_, value) => {
     setBiosamples(value)
   }
 
@@ -345,7 +356,7 @@ export function GeneExpression(props: {
                 fullWidth: true,
                 size: "medium",
                 sx: { minWidth: '200px' },
-                defaultValue: {
+                defaultValue: gene && {
                   name: gene, //only gene needed to set default
                   id: "",
                   coordinates: {
@@ -484,9 +495,9 @@ export function GeneExpression(props: {
           </ToggleButtonGroup>
         </FormControl>
         <FormControl>
-          <FormLabel>{biosamples.length === biosampleTypes.length ? "Biosample Types" : <i>Biosample Types*</i>}</FormLabel>
+          <FormLabel>{biosamples.length === allBiosampleTypes.length ? "Biosample Types" : <i>Biosample Types*</i>}</FormLabel>
           <MultiSelect
-            options={biosampleTypes}
+            options={allBiosampleTypes}
             onChange={handleSetBiosamples}
             placeholder="Filter Biosamples"
             limitTags={2}
@@ -494,8 +505,10 @@ export function GeneExpression(props: {
         </FormControl>
         <FormControl>
           <FormLabel>{selectedTissues.length === availableTissues.length ? "Tissues" : <i>Tissues*</i>}</FormLabel>
+          {/* disabling options works, but they're still checked... need to at least show them as unchecked. */}
           <MultiSelect
             options={availableTissues}
+            getOptionDisabled={option => !option.types.some(x => biosamples.includes(x))}
             onChange={handleSetTissues}
             placeholder="Filter Tissues"
             limitTags={2}

--- a/screen2.0/src/app/applets/gene-expression/geneexpression.tsx
+++ b/screen2.0/src/app/applets/gene-expression/geneexpression.tsx
@@ -300,14 +300,35 @@ export function GeneExpression(props: {
 
   const handleSetBiosamples: MultiSelectOnChange<BiosampleType> = (_, value) => {
     setBiosamples(value)
-    //when changing biosample types, need to manually modify the selected tissues to uncheck those which no longer
-    setSelectedTissues(
-      availableTissues.filter(x => x.types.some(y => value.includes(y)))
-    )
   }
+
+  const resetBiosamples = () => {
+    setBiosamples(allBiosampleTypes)
+  }
+
+  const resetTissues = () => [
+    setSelectedTissues(availableTissues)
+  ]
 
   const handleSetGene = (newGene: string) => {
     setGene(newGene)
+  }
+
+  const ResetButton = ({ onClick }: { onClick: React.MouseEventHandler<HTMLButtonElement> }) => {
+    return (
+      <Button
+        variant="text"
+        size="small"
+        onClick={onClick}
+        endIcon={<Close />}
+        sx={{ 
+          p: 0,
+          '& .MuiButton-icon': {ml: 0.5}
+        }}
+      >
+        <i>Reset</i>
+      </Button>
+    )
   }
 
   return (
@@ -499,17 +520,35 @@ export function GeneExpression(props: {
           </ToggleButtonGroup>
         </FormControl>
         <FormControl>
-          <FormLabel>{biosamples.length === allBiosampleTypes.length ? "Biosample Types" : <i>Biosample Types*</i>}</FormLabel>
+          <FormLabel>
+            {biosamples.length === allBiosampleTypes.length ? "Biosample Types" :
+            <Stack direction="row" justifyContent={"space-between"}>
+              <i>Biosample Types*</i>
+              <ResetButton onClick={resetBiosamples} />
+            </Stack>
+            }
+          </FormLabel>
           <MultiSelect
             options={allBiosampleTypes}
             value={biosamples}
+            getOptionDisabled={option => !selectedTissues.some(x => x.types.includes(option))}
             onChange={handleSetBiosamples}
             placeholder="Filter Biosamples"
             limitTags={2}
           />
         </FormControl>
         <FormControl>
-          <FormLabel>{selectedTissues.length === availableTissues.length ? "Tissues" : <i>Tissues*</i>}</FormLabel>
+          <FormLabel>
+            {selectedTissues.length === availableTissues.length ? "Tissue/Organ of Origin" :
+              <Stack direction="row" justifyContent={"space-between"}>
+                <i>Tissue/Organ of Origin*</i>
+                <Button variant="text" size="small" onClick={resetTissues} endIcon={<Close />} sx={{ p: 0 }}>
+                  <i>Reset</i>
+                </Button>
+                <ResetButton onClick={resetTissues} />
+              </Stack>
+            }
+          </FormLabel>
           <MultiSelect
             options={availableTissues}
             value={selectedTissues}

--- a/screen2.0/src/app/applets/gene-expression/geneexpression.tsx
+++ b/screen2.0/src/app/applets/gene-expression/geneexpression.tsx
@@ -29,6 +29,23 @@ type MultiSelectTissue = {label: string, types: BiosampleType[]}
 //extracted from generated types, needed the nested type to pass as type argument to BarData<T>
 type GeneDataset = { __typename?: 'GeneDataset', biosample: string, tissue?: string | null, cell_compartment?: string | null, biosample_type?: string | null, assay_term_name?: string | null, accession: string, gene_quantification_files?: Array<{ __typename?: 'GeneQuantificationFile', accession: string, biorep?: number | null, quantifications?: Array<{ __typename?: 'GeneQuantification', tpm: number, file_accession: string } | null> | null } | null> | null }
 
+export const ResetButton = ({ onClick }: { onClick: React.MouseEventHandler<HTMLButtonElement> }) => {
+  return (
+    <Button
+      variant="text"
+      size="small"
+      onClick={onClick}
+      endIcon={<Close />}
+      sx={{ 
+        p: 0,
+        '& .MuiButton-icon': {ml: 0.5}
+      }}
+    >
+      <i>Reset</i>
+    </Button>
+  )
+}
+
 export function GeneExpression(props: {
   assembly: Assembly
   genes?: { name: string, linkedBy?: string[] }[]
@@ -314,23 +331,6 @@ export function GeneExpression(props: {
     setGene(newGene)
   }
 
-  const ResetButton = ({ onClick }: { onClick: React.MouseEventHandler<HTMLButtonElement> }) => {
-    return (
-      <Button
-        variant="text"
-        size="small"
-        onClick={onClick}
-        endIcon={<Close />}
-        sx={{ 
-          p: 0,
-          '& .MuiButton-icon': {ml: 0.5}
-        }}
-      >
-        <i>Reset</i>
-      </Button>
-    )
-  }
-
   return (
     <Stack spacing={2}>
       <Stack direction="row" justifyContent={"space-between"}>
@@ -542,9 +542,6 @@ export function GeneExpression(props: {
             {selectedTissues.length === availableTissues.length ? "Tissue/Organ of Origin" :
               <Stack direction="row" justifyContent={"space-between"}>
                 <i>Tissue/Organ of Origin*</i>
-                <Button variant="text" size="small" onClick={resetTissues} endIcon={<Close />} sx={{ p: 0 }}>
-                  <i>Reset</i>
-                </Button>
                 <ResetButton onClick={resetTissues} />
               </Stack>
             }

--- a/screen2.0/src/app/search/_ccredetails/rampage.tsx
+++ b/screen2.0/src/app/search/_ccredetails/rampage.tsx
@@ -32,6 +32,7 @@ import { capitalizeWords } from "./utils"
 import DownloadDialog, { FileOption } from "../../applets/gwas/_lollipop-plot/DownloadDialog"
 import { capitalizeFirstLetter, downloadObjArrayAsTSV, downloadSVG, downloadSvgAsPng } from "../../applets/gwas/helpers"
 import MultiSelect, { MultiSelectOnChange } from "../../applets/gene-expression/MultiSelect"
+import { ResetButton } from "../../applets/gene-expression/geneexpression"
 
 export type RampagePeak = {
   value: number,
@@ -93,7 +94,7 @@ export default function Rampage(props: { genes: { name: string, linkedBy?: strin
     setSearch(event.target.value)
   };
 
-  const handleSetTissues: MultiSelectOnChange = (_, value) => {
+  const handleSetTissues: MultiSelectOnChange<string> = (_, value) => {
     setSelectedTissues(value)
   }
 
@@ -250,6 +251,10 @@ export default function Rampage(props: { genes: { name: string, linkedBy?: strin
     )
   }, [loadingRampage, errorRampage, peakIsAvailable, gene, selectedPeak, plotData])
 
+  const resetTissues = () => {
+    setSelectedTissues(availableTissues)
+  }
+
   return (loadingRampage ? <LoadingMessage /> :
     <Stack spacing={2}>
       <Stack width={"100%"} direction="row" mb={1} justifyContent={"space-between"}>
@@ -352,9 +357,17 @@ export default function Rampage(props: { genes: { name: string, linkedBy?: strin
           </Select>
         </FormControl>
         <FormControl>
-          <FormLabel>{selectedTissues.length === availableTissues.length ? "Tissues" : <i>Tissues*</i>}</FormLabel>
+          <FormLabel>
+            {selectedTissues.length === availableTissues.length ? "Tissue/Organ of Origin" :
+              <Stack direction="row" justifyContent={"space-between"}>
+                <i>Tissue/Organ of Origin*</i>
+                <ResetButton onClick={resetTissues} />
+              </Stack>
+            }
+          </FormLabel>
           <MultiSelect
             options={availableTissues}
+            value={selectedTissues}
             onChange={handleSetTissues}
             placeholder="Filter Tissues"
             limitTags={2}

--- a/screen2.0/src/theme.ts
+++ b/screen2.0/src/theme.ts
@@ -23,6 +23,13 @@ const theme = createTheme({
         }),
       },
     },
+    MuiButton: {
+      styleOverrides: {
+        root: {
+          textTransform: "none"
+        }
+      }
+    }
   },
 });
 


### PR DESCRIPTION
- Fixes gene autocomplete displaying "null" when swapping assemblies
- Provides better behavior for the MultiSelect component
   - Options are now disabled when they are no longer valid based on the state of the other MultiSelect. 
   - Checked state is maintained when options are disabled, but the corresponding tags are hidden and their checkbox is shown in intermediate state if checked