### PR TITLE
Refactor biosample track handling in SearchBrowserView

### DIFF
--- a/screen2.0/src/app/search/_gbview/SearchBrowserView.tsx
+++ b/screen2.0/src/app/search/_gbview/SearchBrowserView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from "react";
+import { useMemo } from "react";
 import {
   Browser,
   createBrowserStore,
@@ -98,51 +98,7 @@ export default function SearchBrowserView({
         />
       ),
     };
-    return [geneTrack, ccreTrack, ...tracks];
-  }, [
-    coordinates.assembly,
-    geneName,
-    addHighlight,
-    removeHighlight,
-    cCREClick,
-  ]);
-
-  const trackStore = createTrackStore(initialTracks);
-  return (
-    <div>
-      <BiosampleAdder
-        biosample={biosample}
-        trackStore={trackStore}
-        browserStore={browserStore}
-        cCREClick={cCREClick}
-      />
-      <GBControls assembly={coordinates.assembly} browserStore={browserStore} />
-      <Browser browserStore={browserStore} trackStore={trackStore} />
-    </div>
-  );
-}
-
-function BiosampleAdder({ biosample, trackStore, browserStore, cCREClick }) {
-  const tracks = trackStore((state) => state.tracks);
-  const insertTrack = trackStore((state) => state.insertTrack);
-  const removeTrack = trackStore((state) => state.removeTrack);
-
-  const addHighlight = browserStore((state) => state.addHighlight);
-  const removeHighlight = browserStore((state) => state.removeHighlight);
-
-  useEffect(() => {
-    if (!biosample) {
-      // Remove existing biosample tracks
-      const existingBiosampleTracks = tracks.filter((track) =>
-        track.id.startsWith("biosample-")
-      );
-      existingBiosampleTracks.forEach((track) => {
-        removeTrack(track.id);
-      });
-      return;
-    }
-
-    // Add new biosample tracks if biosample is provided
+    let biosampleTracks: Track[] = [];
     if (biosample) {
       const onHover = (item: Rect) => {
         addHighlight({
@@ -160,19 +116,30 @@ function BiosampleAdder({ biosample, trackStore, browserStore, cCREClick }) {
         cCREClick(item);
       };
 
-      const biosampleTracks = generateBiosampleTracks(
+      biosampleTracks = generateBiosampleTracks(
         biosample,
         onHover,
         onLeave,
         onClick,
         colors
       );
-      biosampleTracks.forEach((track) => {
-        insertTrack(track);
-      });
     }
-  }, [biosample]);
-  return null;
+    return [geneTrack, ccreTrack, ...tracks, ...biosampleTracks];
+  }, [
+    coordinates.assembly,
+    geneName,
+    addHighlight,
+    removeHighlight,
+    cCREClick,
+  ]);
+
+  const trackStore = createTrackStore(initialTracks);
+  return (
+    <div>
+      <GBControls assembly={coordinates.assembly} browserStore={browserStore} />
+      <Browser browserStore={browserStore} trackStore={trackStore} />
+    </div>
+  );
 }
 
 export function expandCoordinates(

--- a/screen2.0/src/app/search/page.tsx
+++ b/screen2.0/src/app/search/page.tsx
@@ -58,7 +58,9 @@ import { LINKED_GENES } from "./_ccredetails/queries";
 import { gql } from "../../graphql/__generated__/gql";
 import { GROUP_COLOR_MAP } from "./_ccredetails/utils";
 import UrlErrorDialog from "./UrlErrorDialog";
-import SearchBrowserView, { expandCoordinates } from "./_gbview/SearchBrowserView";
+import SearchBrowserView, {
+  expandCoordinates,
+} from "./_gbview/SearchBrowserView";
 // import { track } from "@vercel/analytics/react"
 
 /**
@@ -178,8 +180,6 @@ function CircularProgressWithLabel(
     </Box>
   );
 }
-
-
 
 /**
  * @todo move this to a better location
@@ -350,9 +350,9 @@ export default function Search(props: {
           }
 
           //No human or mouse genes have "chr" followed by a number, so safe to check this way
-          if (/chr\d+/.test(encodeInput)) searchType = "region"
+          if (/chr\d+/.test(encodeInput)) searchType = "region";
           //handle rs1 edge case in case user searches in lowercase
-          else if (encodeInput.toLowerCase() === "rs1") searchType = "gene"
+          else if (encodeInput.toLowerCase() === "rs1") searchType = "gene";
           //check for "rs" followed by number. Genes RS1 and Rs1 exist, but lowercase r is differentiator
           else if (/rs\d+/.test(encodeInput)) searchType = "snp";
           //check for beginning of cCRE accession. No Genes start with these
@@ -686,16 +686,24 @@ export default function Search(props: {
    */
   useEffect(() => {
     //Check if the URL params representing state are stale
+    const urlMQP = constructMainQueryParamsFromURL(searchParams);
+    const urlFC = constructFilterCriteriaFromURL(searchParams);
+
+    // Compare everything except biosample objects (URL has partial, state has full)
+    const urlMQPNoBiosample = { ...urlMQP, biosample: null };
+    const stateMQPNoBiosample = { ...mainQueryParams, biosample: null };
+    const biosampleNamesDiff = (urlMQP.biosample?.name || null) !== (mainQueryParams.biosample?.name || null);
+    
+    const mqpDiff = JSON.stringify(urlMQPNoBiosample) !== JSON.stringify(stateMQPNoBiosample) || biosampleNamesDiff;
+    const fcDiff = JSON.stringify(urlFC) !== JSON.stringify(filterCriteria);
+    const pageDiff = (searchParams.page ? +searchParams.page : 0) !== page;
+    const accessionsDiff = (searchParams.accessions || "") !== opencCREs.map((x) => x.ID).join(",");
+
     if (
       opencCREsInitialized &&
       !loadingFetch &&
       //bug potentially?
-      (JSON.stringify(constructMainQueryParamsFromURL(searchParams)) !==
-        JSON.stringify(mainQueryParams) ||
-        JSON.stringify(constructFilterCriteriaFromURL(searchParams)) !==
-          JSON.stringify(filterCriteria) ||
-        +searchParams.page !== page ||
-        searchParams.accessions !== opencCREs.map((x) => x.ID).join(","))
+      (mqpDiff || fcDiff || pageDiff || accessionsDiff)
     ) {
       const newURL = constructSearchURL(
         mainQueryParams,


### PR DESCRIPTION
Simplifies biosample track management by removing the BiosampleAdder component and integrating biosample track generation directly into the initialTracks useMemo. Also improves URL state comparison logic in search/page.tsx for more accurate state synchronization. Only compares biosample names instead of entire object as it is initially filled with null values. This caused the comparison to infinitely fail, and the genome browser unable to populate with new tracks.